### PR TITLE
update(vat): standard VAT in Romania is now 19% (Q1 2017)

### DIFF
--- a/src/vatrates.js
+++ b/src/vatrates.js
@@ -266,7 +266,7 @@ var VATRates = {
     "rates": {
       "superReduced": false,
       "reduced": [5, 9],
-      "standard": 20,
+      "standard": 19,
       "parking": false
     }
   },

--- a/src/vatrates.json
+++ b/src/vatrates.json
@@ -246,7 +246,7 @@
     "rates": {
       "superReduced": false,
       "reduced": [5, 9],
-      "standard": 20,
+      "standard": 19,
       "parking": false
     }
   },

--- a/src/vatrates.php
+++ b/src/vatrates.php
@@ -253,7 +253,7 @@ $VATRates = array(
     "rates" => array(
       "superReduced" => false,
       "reduced" => array(5, 9),
-      "standard" => 20,
+      "standard" => 19,
       "parking" => false
     )
   ),

--- a/vatrates.js
+++ b/vatrates.js
@@ -1,6 +1,6 @@
 /*!
- * VATRates - v1.2.2
- * Last update: 2016-08-27T16:28:51
+ * VATRates - v1.2.3
+ * Last update: 2017-02-01T13:32:49
  * MIT License
  */
 
@@ -266,7 +266,7 @@ var VATRates = {
     "rates": {
       "superReduced": false,
       "reduced": [5, 9],
-      "standard": 20,
+      "standard": 19,
       "parking": false
     }
   },

--- a/vatrates.json
+++ b/vatrates.json
@@ -246,7 +246,7 @@
     "rates": {
       "superReduced": false,
       "reduced": [5, 9],
-      "standard": 20,
+      "standard": 19,
       "parking": false
     }
   },

--- a/vatrates.php
+++ b/vatrates.php
@@ -1,7 +1,7 @@
 <?php
 /*!
- * VATRates - v1.2.2
- * Last update: 2016-08-27T16:28:51
+ * VATRates - v1.2.3
+ * Last update: 2017-02-01T13:32:49
  * MIT License
  */
 
@@ -253,7 +253,7 @@ $VATRates = array(
     "rates" => array(
       "superReduced" => false,
       "reduced" => array(5, 9),
-      "standard" => 20,
+      "standard" => 19,
       "parking" => false
     )
   ),


### PR DESCRIPTION
http://www.vatlive.com/vat-news/romania-cuts-vat-to-19-2017/