### PR TITLE
Update historical VAT rates for Germany

### DIFF
--- a/src/json/vatrates.json
+++ b/src/json/vatrates.json
@@ -127,10 +127,17 @@
       "countryCode": "DE",
       "periods": [
         {
-          "effectiveFrom": "0000-01-01",
+          "effectiveFrom": "2007-01-01",
           "rates": {
             "reduced": [7],
             "standard": 19
+          }
+        },
+        {
+          "effectiveFrom": "0000-01-01",
+          "rates": {
+            "reduced": [7],
+            "standard": 16
           }
         }
       ]


### PR DESCRIPTION
The standard VAT rate before 2007/01/01 was 16%.